### PR TITLE
feat(scripts): add monad-org-export for org export/migration/backup

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,7 @@ its usage and limitations.
 | Script | Purpose | Language | Monad API surface | Category | Docs |
 |---|---|---|---|---|---|
 | [`tls-cert-to-syslog-input`](tls-cert-to-syslog-input/) | Register device TLS-certificate SHA-256 fingerprints on a pipeline's Syslog input so SNI-less sources route correctly | Bash | `GET /v1/organizations`, `GET /v2/{org}/pipelines/{id}`, `GET /v1/{org}/inputs/{id}`, `PATCH /v2/{org}/inputs/{id}` | Inputs / routing | [README](tls-cert-to-syslog-input/README.md) |
-| [`monad-org-export`](monad-org-export/) | Export an entire organization to a Terraform module, then migrate it between instances (SaaS ↔ self-hosted) or back it up to Git | Python | `GET /v1/{org}/inputs\|outputs\|transforms`, `GET /v3/{org}/enrichments`, `GET /v2/{org}/secrets\|pipelines` | Migration / backup | [README](monad-org-export/README.md) |
+| [`monad-org-export`](monad-org-export/) | Export an entire organization to a Terraform module, then migrate it between instances (SaaS ↔ self-hosted) or back it up to Git | Python / Bash | `GET /v1/{org}/inputs\|outputs\|transforms`, `GET /v3/{org}/enrichments`, `GET /v2/{org}/secrets\|pipelines` | Migration / backup | [README](monad-org-export/README.md) |
 
 ## Layout
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ its usage and limitations.
 | Script | Purpose | Language | Monad API surface | Category | Docs |
 |---|---|---|---|---|---|
 | [`tls-cert-to-syslog-input`](tls-cert-to-syslog-input/) | Register device TLS-certificate SHA-256 fingerprints on a pipeline's Syslog input so SNI-less sources route correctly | Bash | `GET /v1/organizations`, `GET /v2/{org}/pipelines/{id}`, `GET /v1/{org}/inputs/{id}`, `PATCH /v2/{org}/inputs/{id}` | Inputs / routing | [README](tls-cert-to-syslog-input/README.md) |
+| [`monad-org-export`](monad-org-export/) | Export an entire organization to a Terraform module, then migrate it between instances (SaaS ↔ self-hosted) or back it up to Git | Python | `GET /v1/{org}/inputs\|outputs\|transforms`, `GET /v3/{org}/enrichments`, `GET /v2/{org}/secrets\|pipelines` | Migration / backup | [README](monad-org-export/README.md) |
 
 ## Layout
 

--- a/scripts/monad-org-export/README.md
+++ b/scripts/monad-org-export/README.md
@@ -6,6 +6,13 @@ Export an entire Monad **organization** to a self-contained Terraform module,
 then either migrate it to another instance or commit it to Git for backup and
 version control.
 
+Two interchangeable implementations are provided — pick whichever fits your
+environment; they produce the same Terraform module and support the same
+commands:
+
+- **`monad-org-export.py`** — Python 3, standard library only (no `pip install`).
+- **`monad-org-export.sh`** — Bash, using `curl` + `jq`.
+
 Monad's [Terraform provider](https://registry.terraform.io/providers/monad-inc/monad/latest)
 can manage every resource type in an org, but it has **no data sources** — so on
 its own it cannot discover "everything in my org." This tool closes that gap: it
@@ -33,11 +40,17 @@ target:
 
 ## Requirements
 
-- Interpreter: `python` 3.8+ (standard library only — no `pip install`).
-- Tools: [`terraform`](https://developer.hashicorp.com/terraform) **1.5+** (for
-  `apply`, and required by `--emit-imports`); `git` (for `push`). Neither is
-  needed for `export` itself.
-- Platform notes: macOS/Linux. No third-party Python packages.
+- **Python version (`monad-org-export.py`):** `python` 3.8+, standard library
+  only — no third-party packages.
+- **Bash version (`monad-org-export.sh`):** `bash` 3.2+ (macOS default), plus
+  [`curl`](https://curl.se/) and [`jq`](https://jqlang.github.io/jq/).
+- Both: [`terraform`](https://developer.hashicorp.com/terraform) **1.5+** is
+  needed for `apply` (and required by `--emit-imports`); `git` is needed for
+  `push`. Neither is needed for `export` itself.
+- Platform notes: macOS/Linux.
+
+Examples below use the Python entrypoint; substitute `./monad-org-export.sh` for
+the Bash version — the subcommands, flags, and output are identical.
 
 ## Authentication
 
@@ -112,10 +125,13 @@ apply** — import blocks are one-time.
   values, so the module contains secret *definitions* only: each becomes a
   `monad_secret` whose `value` is a sensitive Terraform variable, with a stub in
   `terraform.tfvars.example`. You must supply each value before `apply`.
-- **Secret references inside connector config are remapped best-effort.** Where a
-  connector's `config.secrets` value contains a known exported secret id, it is
-  rewritten to `monad_secret.<name>.reference`. Unrecognized references are
-  emitted literally and flagged in `EXPORT_NOTES.md` for manual remapping.
+- **Secret references inside connector config.** The Python version remaps them
+  best-effort: where a connector's `config.secrets` value contains a known
+  exported secret id, it is rewritten to `monad_secret.<name>.reference`
+  (unrecognized references are emitted literally and flagged in
+  `EXPORT_NOTES.md`). The Bash version emits `config.secrets` verbatim; if you
+  migrate to a different instance, remap those references to
+  `monad_secret.<name>.reference` by hand.
 - **`--emit-imports` requires the resource ids to exist on the target.** It is
   for adopting the *same* org in place, not for cross-instance migration (a
   different instance has different ids). Imported `monad_secret` resources may

--- a/scripts/monad-org-export/README.md
+++ b/scripts/monad-org-export/README.md
@@ -1,0 +1,149 @@
+# monad-org-export
+
+## Purpose
+
+Export an entire Monad **organization** to a self-contained Terraform module,
+then either migrate it to another instance or commit it to Git for backup and
+version control.
+
+Monad's [Terraform provider](https://registry.terraform.io/providers/monad-inc/monad/latest)
+can manage every resource type in an org, but it has **no data sources** — so on
+its own it cannot discover "everything in my org." This tool closes that gap: it
+reads every resource over the Monad REST API and writes a Terraform module
+(`inputs.tf`, `outputs.tf`, `transforms.tf`, `enrichments.tf`, `secrets.tf`,
+`pipelines.tf`, plus provider/variable scaffolding). That single module is the
+artifact behind every workflow below.
+
+The same module works in all directions, because **"SaaS vs. self-hosted" is
+only a different base URL** — the three connection settings (base URL, API
+token, organization id) are the *only* things that change between any source and
+target:
+
+| Scenario | How |
+|---|---|
+| SaaS → SaaS | `export` from one org, `apply` to another |
+| SaaS → self-hosted | `export` from `app.monad.com`, `apply` with `--target-base-url https://monad.your-domain` |
+| self-hosted → SaaS | `export` with `--base-url https://monad.your-domain`, `apply` to `app.monad.com` |
+| either → Git backup | `export`, then `push` to a GitHub/GitLab remote |
+
+**Monad API surface:** `GET /v1/{org}/inputs`, `GET /v1/{org}/outputs`,
+`GET /v1/{org}/transforms`, `GET /v3/{org}/enrichments`, `GET /v2/{org}/secrets`,
+`GET /v2/{org}/pipelines` + `GET /v2/{org}/pipelines/{id}` (all read-only). The
+`apply` and `push` subcommands shell out to `terraform` and `git` respectively.
+
+## Requirements
+
+- Interpreter: `python` 3.8+ (standard library only — no `pip install`).
+- Tools: [`terraform`](https://developer.hashicorp.com/terraform) **1.5+** (for
+  `apply`, and required by `--emit-imports`); `git` (for `push`). Neither is
+  needed for `export` itself.
+- Platform notes: macOS/Linux. No third-party Python packages.
+
+## Authentication
+
+Supply the Monad API token via environment variable (never on the command line,
+so it stays out of the process list):
+
+- `export` reads `MONAD_API_TOKEN` (or `--token-file <path>`).
+- `apply` reads `MONAD_TARGET_API_TOKEN` (falls back to `MONAD_API_TOKEN`), which
+  it passes to Terraform as `TF_VAR_monad_api_token`.
+
+The token must belong to the relevant organization: `export` needs **read**
+access to inputs/outputs/transforms/enrichments/secrets/pipelines; `apply` needs
+**write** access on the target org. The token is sent as
+`Authorization: ApiKey <token>` (matching the official Terraform provider).
+
+## Usage
+
+```bash
+# 1) Export a SaaS org to ./org-tf
+export MONAD_API_TOKEN=...
+./monad-org-export.py export --org-id <SRC_ORG_ID> --out ./org-tf
+
+# 1b) …or export from a self-hosted instance
+./monad-org-export.py export --base-url https://monad.your-domain \
+    --org-id <SRC_ORG_ID> --out ./org-tf
+
+# 2) Migrate into another org (SaaS or self-hosted — just change the URL)
+MONAD_TARGET_API_TOKEN=... ./monad-org-export.py apply --dir ./org-tf \
+    --target-base-url https://app.monad.com --target-org-id <DST_ORG_ID>
+
+# 3) Back up to a Git repo
+./monad-org-export.py push --dir ./org-tf \
+    --remote git@github.com:acme/monad-org-backup.git -m "nightly backup"
+```
+
+### `export` flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--out` | yes | Output directory for the generated module |
+| `--org-id` | yes | Source organization id (or `$MONAD_ORGANIZATION_ID`) |
+| `--base-url` | no | Source instance base URL (default `https://app.monad.com`) |
+| `--token-file` | no | File containing the source API token (alternative to `$MONAD_API_TOKEN`) |
+| `--emit-imports` | no | Also write `imports.tf` with `import {}` blocks to **adopt** the source org's existing resources into Terraform state in place (Terraform 1.5+) instead of creating new ones |
+| `--customer-only` | no | Skip resources whose `managed_by` is not `customer` (system/auto-provisioned) |
+| `--insecure` | no | Skip TLS verification (self-signed self-hosted only; not recommended) |
+
+`export` is read-only. `apply` is the only state-changing step — run
+`terraform plan` in the module directory, or `apply` without `--auto-approve`, to
+preview before committing.
+
+### Adopting an existing org in place (`--emit-imports`)
+
+When the target **is** the org you exported from (e.g. you want to bring an
+existing org under Terraform management without recreating anything), export with
+`--emit-imports`. Terraform reads each resource by id and reconciles state
+instead of planning a create. **Delete `imports.tf` after the first successful
+apply** — import blocks are one-time.
+
+## Inputs / outputs
+
+- **Input:** a reachable Monad instance + an org-scoped API token.
+- **Output / effects:** a Terraform module directory containing one `.tf` file
+  per resource type, `terraform.tfvars.example` (target connection + secret value
+  stubs), `MANIFEST.json` (source-id → Terraform-address map), `EXPORT_NOTES.md`
+  (counts and any warnings), and a generated `README.md`. `push` adds a
+  `.gitignore` that keeps state and `terraform.tfvars` out of the backup repo.
+
+## Limitations & caveats
+
+- **Secret values are never exported.** The Monad API does not return secret
+  values, so the module contains secret *definitions* only: each becomes a
+  `monad_secret` whose `value` is a sensitive Terraform variable, with a stub in
+  `terraform.tfvars.example`. You must supply each value before `apply`.
+- **Secret references inside connector config are remapped best-effort.** Where a
+  connector's `config.secrets` value contains a known exported secret id, it is
+  rewritten to `monad_secret.<name>.reference`. Unrecognized references are
+  emitted literally and flagged in `EXPORT_NOTES.md` for manual remapping.
+- **`--emit-imports` requires the resource ids to exist on the target.** It is
+  for adopting the *same* org in place, not for cross-instance migration (a
+  different instance has different ids). Imported `monad_secret` resources may
+  show a value diff until you supply the value via tfvars.
+- **API-key permissions:** `export` requires read on all listed endpoints;
+  `apply` requires write on the target org.
+- **Idempotency:** `export` overwrites the output directory's `.tf` files on each
+  run. `push` commits only when something changed and (unless `--no-push`) pushes
+  to `origin`.
+- **What it does NOT do:** it does not copy ingested data or pipeline run
+  history; it does not manage users, roles, API keys, or billing. It captures the
+  resource types the Terraform provider supports (inputs, outputs, transforms,
+  enrichments, secrets, pipelines).
+- **Throughput:** list endpoints are paginated 100 at a time and pipelines are
+  fetched individually, so very large orgs make correspondingly many GET calls.
+
+## Safety
+
+- `export` is strictly read-only against Monad. The only state-changing path is
+  `apply`; preview it with `terraform plan` (or omit `--auto-approve`) first.
+- Credentials are read from environment variables or `--token-file`, never from
+  argv, and are never written into the generated module.
+- `push` writes a `.gitignore` excluding `*.tfstate*`, `.terraform/`,
+  `terraform.tfvars`, and `*.auto.tfvars`, so state and secret values are not
+  committed to the backup repo.
+
+## Related
+
+- [Monad Terraform provider](https://registry.terraform.io/providers/monad-inc/monad/latest/docs)
+- [Terraform import blocks](https://developer.hashicorp.com/terraform/language/import)
+- [Monad documentation](https://app.monad.com/docs)

--- a/scripts/monad-org-export/monad-org-export.py
+++ b/scripts/monad-org-export/monad-org-export.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""
+monad-org-export — export a Monad organization's resources as Terraform, then
+migrate them to another instance or commit them to a Git repo for backup.
+
+A Monad organization is fully manageable through the Terraform provider
+(monad-inc/monad), but the provider has no data sources, so it cannot discover
+"everything in my org" on its own. This tool fills that gap: it reads every
+resource from a SOURCE instance over the REST API and writes a self-contained
+Terraform module. That single module then serves every direction of travel:
+
+  - SaaS  -> SaaS     export from one app.monad.com org, apply to another
+  - SaaS  -> on-prem  export from app.monad.com, apply to a self-hosted instance
+  - on-prem -> SaaS   export from a self-hosted instance, apply to app.monad.com
+  - either -> Git     export, then push the module to GitHub/GitLab for backup
+
+"SaaS vs on-prem" is nothing more than a different --base-url; the three
+connection settings (base URL, API token, org id) are all that change between
+any source and any target.
+
+Subcommands:
+  export   read SOURCE org -> write a Terraform module to a directory
+  apply    run `terraform apply` against a TARGET org using that module
+  push     commit the module to a Git remote (backup / version control)
+
+Run `monad-org-export.py <subcommand> --help` for details.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+PROVIDER_SOURCE = "monad-inc/monad"
+DEFAULT_BASE_URL = "https://app.monad.com"
+
+# REST paths per resource type. Monad serves a deliberate mix of API versions
+# (verified against the live API): inputs/outputs/transforms on v1, secrets and
+# pipelines on v2, enrichments on v3. Each entry: (api_version, path_segment,
+# list_envelope_key, terraform_resource_type).
+# Kinds whose HCL shape is `type = ...` + a `config { settings {} secrets {} }`
+# block. Transforms are NOT here — their schema has no `type` and a single
+# required dynamic `config = {...}` attribute, so they are rendered separately.
+RESOURCE_KINDS = [
+    ("v1", "inputs", "inputs", "monad_input"),
+    ("v1", "outputs", "outputs", "monad_output"),
+    ("v3", "enrichments", "enrichments", "monad_enrichment"),
+]
+
+# ---------------------------------------------------------------------------
+# API client
+# ---------------------------------------------------------------------------
+
+
+class MonadAPIError(Exception):
+    pass
+
+
+class Client:
+    """Minimal Monad REST client. Auth header is `Authorization: ApiKey <tok>`
+    (NOT Bearer) — this matches the official Terraform provider's transport."""
+
+    def __init__(self, base_url, token, org_id, insecure=False):
+        self.base = base_url.rstrip("/") + "/api"
+        self.token = token
+        self.org = org_id
+        self._ctx = None
+        if insecure:
+            import ssl
+
+            self._ctx = ssl.create_default_context()
+            self._ctx.check_hostname = False
+            self._ctx.verify_mode = ssl.CERT_NONE
+
+    def _get(self, path):
+        url = self.base + path
+        req = urllib.request.Request(url, headers={"Authorization": "ApiKey " + self.token})
+        try:
+            with urllib.request.urlopen(req, context=self._ctx) as resp:
+                return json.load(resp)
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", "replace")
+            raise MonadAPIError(f"GET {path} -> HTTP {e.code}: {body[:300]}") from None
+        except urllib.error.URLError as e:
+            raise MonadAPIError(f"GET {path} -> {e.reason}") from None
+
+    def list(self, version, segment, envelope_key):
+        """Paginate a list endpoint. Envelope is {"<key>": [...], "pagination":
+        {"total","limit","offset"}}."""
+        out, offset, limit = [], 0, 100
+        while True:
+            d = self._get(f"/{version}/{self.org}/{segment}?limit={limit}&offset={offset}")
+            if isinstance(d, list):  # defensive: bare array
+                out.extend(d)
+                break
+            items = d.get(envelope_key) or _first_list(d)
+            out.extend(items)
+            pg = d.get("pagination") or {}
+            total = pg.get("total")
+            offset += limit
+            if total is None or offset >= total or not items:
+                break
+        return out
+
+    def get(self, version, segment, rid):
+        d = self._get(f"/{version}/{self.org}/{segment}/{rid}")
+        return d.get("data", d) if isinstance(d, dict) else d
+
+
+def _first_list(d):
+    for v in d.values():
+        if isinstance(v, list):
+            return v
+    return []
+
+
+# ---------------------------------------------------------------------------
+# HCL generation
+# ---------------------------------------------------------------------------
+
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+
+
+def hcl_string(s):
+    s = s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\t", "\\t")
+    # Escape Terraform interpolation so literal ${...} / %{...} in data is inert.
+    s = s.replace("${", "$${").replace("%{", "%%{")
+    return f'"{s}"'
+
+
+class Raw(str):
+    """A value emitted verbatim (no quoting) — used for Terraform references."""
+
+
+def hcl_value(v, indent):
+    pad = "  " * indent
+    pad1 = "  " * (indent + 1)
+    if isinstance(v, Raw):
+        return str(v)
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if v is None:
+        return "null"
+    if isinstance(v, (int, float)):
+        return json.dumps(v)
+    if isinstance(v, str):
+        return hcl_string(v)
+    if isinstance(v, list):
+        if not v:
+            return "[]"
+        items = [pad1 + hcl_value(x, indent + 1) for x in v]
+        return "[\n" + ",\n".join(items) + "\n" + pad + "]"
+    if isinstance(v, dict):
+        if not v:
+            return "{}"
+        lines = []
+        for k, val in v.items():
+            key = k if _IDENT_RE.match(str(k)) else hcl_string(str(k))
+            lines.append(f"{pad1}{key} = {hcl_value(val, indent + 1)}")
+        return "{\n" + "\n".join(lines) + "\n" + pad + "}"
+    return hcl_string(str(v))
+
+
+def sanitize_name(name, used):
+    """Turn a resource name into a unique, valid Terraform local name."""
+    base = re.sub(r"[^a-z0-9_]+", "_", (name or "").lower()).strip("_") or "resource"
+    if base[0].isdigit():
+        base = "r_" + base
+    candidate, n = base, 1
+    while candidate in used:
+        n += 1
+        candidate = f"{base}_{n}"
+    used.add(candidate)
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def build_config_block(config, secret_ref_map, warnings, ctx_label):
+    """Render a `config { settings {...} secrets {...} }` block body from the
+    API config object. settings/secrets are dynamic maps, so native HCL objects
+    reproduce them faithfully. Secret references are remapped where recognized."""
+    if not config:
+        return None
+    settings = config.get("settings") or {}
+    secrets = config.get("secrets") or {}
+    lines = []
+    if settings:
+        lines.append(f"    settings = {hcl_value(settings, 2)}")
+    if secrets:
+        remapped = _remap_secret_refs(secrets, secret_ref_map, warnings, ctx_label)
+        lines.append(f"    secrets = {hcl_value(remapped, 2)}")
+    if not lines:
+        return None
+    return "  config {\n" + "\n".join(lines) + "\n  }"
+
+
+def _remap_secret_refs(secrets, secret_ref_map, warnings, ctx_label):
+    """config.secrets values embed an org-specific secret id/reference. Where a
+    value contains a known source secret id, rewrite it to a Terraform reference
+    so it resolves against the recreated secret on the target."""
+    out = {}
+    for slot, val in secrets.items():
+        if isinstance(val, str):
+            for sid, addr in secret_ref_map.items():
+                if sid and sid in val:
+                    out[slot] = Raw(f"{addr}.reference")
+                    break
+            else:
+                out[slot] = val
+                if val:
+                    warnings.append(
+                        f"{ctx_label}: secret slot '{slot}' could not be matched to an "
+                        f"exported secret; its value is emitted literally and may need "
+                        f"manual remapping on the target."
+                    )
+        else:
+            out[slot] = val
+    return out
+
+
+def export(args):
+    token = resolve_token(args, "MONAD_API_TOKEN")
+    if not args.org_id:
+        die("--org-id is required (or set MONAD_ORGANIZATION_ID)")
+    client = Client(args.base_url, token, args.org_id, insecure=args.insecure)
+    outdir = Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    warnings = []
+    id_to_addr = {}       # component id -> "monad_input.foo"
+    secret_ref_map = {}   # secret id    -> "monad_secret.bar"
+    manifest = {"organization_id": args.org_id, "source_base_url": args.base_url, "resources": {}}
+
+    # ---- secrets first (their addresses are referenced by component configs)
+    print("Fetching secrets ...", file=sys.stderr)
+    secrets = client.list("v2", "secrets", "secrets")
+    used_names = set()
+    secret_blocks, secret_vars, secret_tfvars = [], [], []
+    for s in secrets:
+        local = sanitize_name(s.get("name"), used_names)
+        addr = f"monad_secret.{local}"
+        secret_ref_map[s["id"]] = addr
+        manifest["resources"][s["id"]] = {"address": addr, "name": s.get("name"), "type": "secret"}
+        var = f"secret_{local}"
+        block = [f'resource "monad_secret" "{local}" {{']
+        block.append(f"  name  = {hcl_string(s.get('name') or local)}")
+        block.append(f"  value = var.{var}")
+        block.append("}")
+        secret_blocks.append("\n".join(block))
+        secret_vars.append(
+            f'variable "{var}" {{\n'
+            f'  description = {hcl_string("Value for secret: " + (s.get("name") or local))}\n'
+            f"  type        = string\n  sensitive   = true\n}}"
+        )
+        secret_tfvars.append(f'{var} = "REPLACE_ME"  # {s.get("name")}')
+
+    # ---- component resources (inputs/outputs/transforms/enrichments)
+    component_blocks = {tf: [] for _, _, _, tf in RESOURCE_KINDS}
+    for version, segment, env_key, tf_type in RESOURCE_KINDS:
+        print(f"Fetching {segment} ...", file=sys.stderr)
+        try:
+            items = client.list(version, segment, env_key)
+        except MonadAPIError as e:
+            warnings.append(f"Could not list {segment}: {e}")
+            continue
+        for it in items:
+            if args.customer_only and it.get("managed_by") not in (None, "customer"):
+                continue
+            local = sanitize_name(it.get("name"), used_names)
+            addr = f"{tf_type}.{local}"
+            id_to_addr[it["id"]] = addr
+            manifest["resources"][it["id"]] = {
+                "address": addr, "name": it.get("name"), "type": tf_type,
+                "connector_type": it.get("type"),
+            }
+            block = [f'resource "{tf_type}" "{local}" {{']
+            block.append(f"  name        = {hcl_string(it.get('name') or local)}")
+            if it.get("description"):
+                block.append(f"  description = {hcl_string(it['description'])}")
+            block.append(f"  type        = {hcl_string(it.get('type') or '')}")
+            cfg = build_config_block(it.get("config"), secret_ref_map, warnings, addr)
+            if cfg:
+                block.append(cfg)
+            block.append("}")
+            component_blocks[tf_type].append("\n".join(block))
+
+    # ---- transforms (distinct schema: required dynamic `config`, no `type`)
+    print("Fetching transforms ...", file=sys.stderr)
+    transform_blocks = []
+    try:
+        transforms = client.list("v1", "transforms", "transforms")
+    except MonadAPIError as e:
+        warnings.append(f"Could not list transforms: {e}")
+        transforms = []
+    for it in transforms:
+        if args.customer_only and it.get("managed_by") not in (None, "customer"):
+            continue
+        local = sanitize_name(it.get("name"), used_names)
+        addr = f"monad_transform.{local}"
+        id_to_addr[it["id"]] = addr
+        manifest["resources"][it["id"]] = {"address": addr, "name": it.get("name"), "type": "monad_transform"}
+        block = [f'resource "monad_transform" "{local}" {{']
+        block.append(f"  name        = {hcl_string(it.get('name') or local)}")
+        if it.get("description"):
+            block.append(f"  description = {hcl_string(it['description'])}")
+        block.append(f"  config = {hcl_value(it.get('config') or {}, 1)}")
+        block.append("}")
+        transform_blocks.append("\n".join(block))
+
+    # ---- pipelines (need per-pipeline GET for nodes/edges)
+    print("Fetching pipelines ...", file=sys.stderr)
+    pipeline_blocks = []
+    pipelines = client.list("v2", "pipelines", "pipelines")
+    for p in pipelines:
+        full = client.get("v2", "pipelines", p["id"])
+        block = render_pipeline(full, id_to_addr, used_names, warnings, manifest)
+        if block:
+            pipeline_blocks.append(block)
+
+    write_module(
+        outdir, args, secret_blocks, secret_vars, secret_tfvars,
+        component_blocks, transform_blocks, pipeline_blocks, manifest, warnings,
+    )
+
+    print(f"\nExported to {outdir}/", file=sys.stderr)
+    print(f"  secrets:    {len(secret_blocks)}", file=sys.stderr)
+    for _, seg, _, tf in RESOURCE_KINDS:
+        print(f"  {seg:10} {len(component_blocks[tf])}", file=sys.stderr)
+    print(f"  transforms: {len(transform_blocks)}", file=sys.stderr)
+    print(f"  pipelines:  {len(pipeline_blocks)}", file=sys.stderr)
+    if warnings:
+        print(f"\n{len(warnings)} warning(s) — see {outdir}/EXPORT_NOTES.md", file=sys.stderr)
+
+
+def render_pipeline(p, id_to_addr, used_names, warnings, manifest):
+    name = p.get("name") or "pipeline"
+    local = sanitize_name(name, used_names)
+    manifest["resources"][p.get("id")] = {"address": f"monad_pipeline.{local}", "name": name, "type": "pipeline"}
+    nodes = p.get("nodes") or []
+    edges = p.get("edges") or []
+
+    # node instance id -> slug (edges in the API reference node ids; the
+    # provider wires edges by slug, so we translate).
+    nodeid_to_slug = {n.get("id"): n.get("slug") for n in nodes if n.get("id")}
+
+    lines = [f'resource "monad_pipeline" "{local}" {{']
+    lines.append(f"  name        = {hcl_string(name)}")
+    if p.get("description"):
+        lines.append(f"  description = {hcl_string(p['description'])}")
+    lines.append(f"  enabled     = {'true' if p.get('enabled', True) else 'false'}")
+
+    for n in nodes:
+        cid = n.get("component_id")
+        ref = id_to_addr.get(cid)
+        comp_id = Raw(f"{ref}.id") if ref else cid
+        if not ref and cid:
+            warnings.append(
+                f"pipeline '{name}': node '{n.get('slug')}' references component "
+                f"{cid} that was not exported; emitting the literal id. It will not "
+                f"resolve on a different instance."
+            )
+        lines.append("  nodes {")
+        lines.append(f"    slug           = {hcl_string(n.get('slug') or '')}")
+        lines.append(f"    component_type = {hcl_string(n.get('component_type') or '')}")
+        lines.append(f"    component_id   = {comp_id if isinstance(comp_id, Raw) else hcl_string(comp_id or '')}")
+        lines.append("  }")
+
+    for e in edges:
+        frm = nodeid_to_slug.get(e.get("from_node_instance_id"), "")
+        to = nodeid_to_slug.get(e.get("to_node_instance_id"), "")
+        cond = e.get("conditions") or {}
+        lines.append("  edges {")
+        if e.get("name"):
+            lines.append(f"    name                    = {hcl_string(e['name'])}")
+        if e.get("description"):
+            lines.append(f"    description             = {hcl_string(e['description'])}")
+        lines.append(f"    from_node_instance_slug = {hcl_string(frm)}")
+        lines.append(f"    to_node_instance_slug   = {hcl_string(to)}")
+        lines.append("    condition {")
+        lines.append(f"      operator = {hcl_string(cond.get('operator') or 'always')}")
+        for c in cond.get("conditions") or []:
+            cc = c.get("config") or {}
+            lines.append("      conditions {")
+            if c.get("type_id"):
+                lines.append(f"        type_id = {hcl_string(c['type_id'])}")
+            cfg_lines = []
+            if cc.get("key"):
+                cfg_lines.append(f"          key   = {hcl_string(str(cc['key']))}")
+            if cc.get("value") not in (None, "", []):
+                # provider expects a list of strings; coerce scalars/elements.
+                raw = cc["value"]
+                vals = raw if isinstance(raw, list) else [raw]
+                vals = [str(v) for v in vals]
+                cfg_lines.append(f"          value = {hcl_value(vals, 5)}")
+            if cc.get("rate"):
+                cfg_lines.append(f"          rate  = {hcl_string(str(cc['rate']))}")
+            if cfg_lines:
+                lines.append("        config {")
+                lines.extend(cfg_lines)
+                lines.append("        }")
+            lines.append("      }")
+        lines.append("    }")
+        lines.append("  }")
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def write_module(outdir, args, secret_blocks, secret_vars, secret_tfvars,
+                 component_blocks, transform_blocks, pipeline_blocks, manifest, warnings):
+    def w(fn, content):
+        (outdir / fn).write_text(content.rstrip() + "\n")
+
+    w("versions.tf", (
+        "terraform {\n"
+        '  required_version = ">= 1.5"\n'
+        "  required_providers {\n"
+        "    monad = {\n"
+        f'      source = "{PROVIDER_SOURCE}"\n'
+        "    }\n  }\n}\n"
+    ))
+    w("provider.tf", (
+        'provider "monad" {\n'
+        "  base_url        = var.monad_base_url\n"
+        "  api_token       = var.monad_api_token\n"
+        "  organization_id = var.monad_organization_id\n"
+        "}\n"
+    ))
+    conn_vars = (
+        'variable "monad_base_url" {\n  type    = string\n'
+        f'  default = "{DEFAULT_BASE_URL}"\n}}\n\n'
+        'variable "monad_api_token" {\n  type      = string\n  sensitive = true\n}\n\n'
+        'variable "monad_organization_id" {\n  type = string\n}\n'
+    )
+    w("variables.tf", conn_vars + ("\n\n" + "\n\n".join(secret_vars) if secret_vars else ""))
+    if secret_blocks:
+        w("secrets.tf", "\n\n".join(secret_blocks))
+    for _, seg, _, tf in RESOURCE_KINDS:
+        if component_blocks[tf]:
+            w(f"{seg}.tf", "\n\n".join(component_blocks[tf]))
+    if transform_blocks:
+        w("transforms.tf", "\n\n".join(transform_blocks))
+    if pipeline_blocks:
+        w("pipelines.tf", "\n\n".join(pipeline_blocks))
+
+    if getattr(args, "emit_imports", False):
+        # `import {}` blocks adopt EXISTING resources (matched by their source
+        # ids) into Terraform state — use these when applying against the SAME
+        # org you exported from, so `apply` reconciles instead of duplicating.
+        # Remove imports.tf after the first successful apply.
+        blocks = [
+            "# Generated by monad-org-export --emit-imports.",
+            "# Adopts the source org's existing resources into Terraform state.",
+            "# Requires Terraform >= 1.5. Delete this file after the first apply.",
+            "# NOTE: secret VALUES are still not readable, so an imported",
+            "# monad_secret may show a value diff until you supply it via tfvars.",
+            "",
+        ]
+        for rid, meta in manifest["resources"].items():
+            blocks.append(f'import {{\n  to = {meta["address"]}\n  id = {hcl_string(rid)}\n}}')
+        w("imports.tf", "\n".join(blocks))
+
+    tfvars = [
+        "# Target connection — fill in the instance you are applying TO.",
+        f'monad_base_url        = "{DEFAULT_BASE_URL}"   # self-hosted: https://monad.your-domain',
+        'monad_api_token       = "REPLACE_ME"',
+        'monad_organization_id = "REPLACE_ME"',
+    ]
+    if secret_tfvars:
+        tfvars += ["", "# Secret values are NOT exported (Monad never returns them). Supply each:"]
+        tfvars += secret_tfvars
+    w("terraform.tfvars.example", "\n".join(tfvars))
+
+    w("MANIFEST.json", json.dumps(manifest, indent=2))
+    w("EXPORT_NOTES.md", render_notes(warnings, manifest))
+    w("README.md", render_readme())
+
+
+def render_notes(warnings, manifest):
+    counts = {}
+    for r in manifest["resources"].values():
+        counts[r["type"]] = counts.get(r["type"], 0) + 1
+    lines = ["# Export notes\n", f"Source org: `{manifest['organization_id']}`",
+             f"Source URL: `{manifest['source_base_url']}`\n", "## Resource counts\n"]
+    for t, c in sorted(counts.items()):
+        lines.append(f"- {t}: {c}")
+    lines.append("\n## Secrets\n")
+    lines.append("Secret **values are never returned by the Monad API**, so this export "
+                 "contains secret *definitions* only. Before `apply`, set each "
+                 "`secret_*` variable in `terraform.tfvars` (or via `TF_VAR_secret_*`).")
+    if warnings:
+        lines.append("\n## Warnings\n")
+        for wn in warnings:
+            lines.append(f"- {wn}")
+    return "\n".join(lines)
+
+
+def render_readme():
+    return (
+        "# Monad organization export (Terraform)\n\n"
+        "Generated by `monad-org-export.py`. This module is a faithful, portable\n"
+        "snapshot of a Monad organization: inputs, outputs, transforms, enrichments,\n"
+        "secrets (definitions only), and pipelines.\n\n"
+        "## Apply to a target instance\n\n"
+        "```sh\n"
+        "cp terraform.tfvars.example terraform.tfvars   # then edit it\n"
+        "terraform init\n"
+        "terraform plan\n"
+        "terraform apply\n"
+        "```\n\n"
+        "Connection settings (`monad_base_url`, `monad_api_token`,\n"
+        "`monad_organization_id`) select the target. `https://app.monad.com` is the\n"
+        "SaaS default; point `monad_base_url` at your own hostname for a self-hosted\n"
+        "instance. Nothing else differs between SaaS and on-prem.\n\n"
+        "## Secrets\n\n"
+        "Secret values are not exported (the API never returns them). Set each\n"
+        "`secret_*` variable before applying — see `EXPORT_NOTES.md`.\n\n"
+        "## Files\n\n"
+        "- `versions.tf` / `provider.tf` / `variables.tf` — provider + inputs\n"
+        "- `inputs.tf` `outputs.tf` `transforms.tf` `enrichments.tf` `secrets.tf` `pipelines.tf`\n"
+        "- `MANIFEST.json` — source id -> Terraform address map\n"
+        "- `EXPORT_NOTES.md` — counts, caveats, and any export warnings\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+def apply(args):
+    d = Path(args.dir)
+    if not (d / "versions.tf").exists():
+        die(f"{d} does not look like an exported module (no versions.tf)")
+    env = dict(os.environ)
+    if args.target_base_url:
+        env["TF_VAR_monad_base_url"] = args.target_base_url
+    if args.target_org_id:
+        env["TF_VAR_monad_organization_id"] = args.target_org_id
+    token = resolve_token(args, "MONAD_TARGET_API_TOKEN", required=False)
+    if token:
+        env["TF_VAR_monad_api_token"] = token
+    run(["terraform", "init", "-input=false"], cwd=d, env=env)
+    cmd = ["terraform", "apply", "-input=false"]
+    if args.auto_approve:
+        cmd.append("-auto-approve")
+    run(cmd, cwd=d, env=env)
+
+
+# ---------------------------------------------------------------------------
+# push (Git backup / version control)
+# ---------------------------------------------------------------------------
+
+
+def push(args):
+    d = Path(args.dir)
+    if not d.exists():
+        die(f"{d} does not exist")
+    # A .gitignore so state/secrets never get committed to the backup repo.
+    (d / ".gitignore").write_text(
+        "*.tfstate\n*.tfstate.*\n.terraform/\n.terraform.lock.hcl\n"
+        "terraform.tfvars\n*.auto.tfvars\n"
+    )
+    if not (d / ".git").exists():
+        run(["git", "init", "-b", args.branch], cwd=d)
+    else:
+        # ensure we are on the requested branch
+        run(["git", "checkout", "-B", args.branch], cwd=d)
+    if args.remote:
+        existing = subprocess.run(["git", "remote"], cwd=d, capture_output=True, text=True).stdout.split()
+        if "origin" in existing:
+            run(["git", "remote", "set-url", "origin", args.remote], cwd=d)
+        else:
+            run(["git", "remote", "add", "origin", args.remote], cwd=d)
+    run(["git", "add", "-A"], cwd=d)
+    # Commit only if there is something staged.
+    if subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=d).returncode != 0:
+        run(["git", "commit", "-m", args.message], cwd=d)
+    else:
+        print("Nothing to commit (working tree matches last backup).", file=sys.stderr)
+    if args.remote and not args.no_push:
+        run(["git", "push", "-u", "origin", args.branch], cwd=d)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_token(args, env_name, required=True):
+    if getattr(args, "token_file", None):
+        tok = Path(args.token_file).read_text().strip()
+    else:
+        tok = os.environ.get(env_name) or os.environ.get("MONAD_API_TOKEN")
+    if not tok and required:
+        die(f"API token required: set ${env_name} or pass --token-file. "
+            f"(Tokens are read from env/file, never argv, to keep them out of `ps`.)")
+    return tok
+
+
+def run(cmd, cwd=None, env=None):
+    print("+ " + " ".join(cmd), file=sys.stderr)
+    r = subprocess.run(cmd, cwd=cwd, env=env)
+    if r.returncode != 0:
+        die(f"command failed ({r.returncode}): {' '.join(cmd)}")
+
+
+def die(msg):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        prog="monad-org-export.py",
+        description="Export a Monad organization to Terraform; migrate it to another "
+                    "instance or back it up to Git.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "examples:\n"
+            "  # Export a SaaS org to ./org-tf\n"
+            "  export MONAD_API_TOKEN=...\n"
+            "  monad-org-export.py export --org-id <SRC_ORG> --out ./org-tf\n\n"
+            "  # Export from a self-hosted instance instead\n"
+            "  monad-org-export.py export --base-url https://monad.corp.internal \\\n"
+            "      --org-id <SRC_ORG> --out ./org-tf\n\n"
+            "  # Migrate into another org (SaaS or on-prem -- just change the URL)\n"
+            "  MONAD_TARGET_API_TOKEN=... monad-org-export.py apply --dir ./org-tf \\\n"
+            "      --target-base-url https://app.monad.com --target-org-id <DST_ORG>\n\n"
+            "  # Back up to a Git repo\n"
+            "  monad-org-export.py push --dir ./org-tf \\\n"
+            "      --remote git@github.com:acme/monad-org-backup.git -m 'nightly backup'\n"
+        ),
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    e = sub.add_parser("export", help="read a SOURCE org and write a Terraform module",
+                       formatter_class=argparse.RawDescriptionHelpFormatter)
+    e.add_argument("--base-url", default=os.environ.get("MONAD_BASE_URL", DEFAULT_BASE_URL),
+                   help=f"source instance base URL (default {DEFAULT_BASE_URL})")
+    e.add_argument("--org-id", default=os.environ.get("MONAD_ORGANIZATION_ID"),
+                   help="source organization id (or $MONAD_ORGANIZATION_ID)")
+    e.add_argument("--out", required=True, help="output directory for the module")
+    e.add_argument("--token-file", help="file containing the source API token")
+    e.add_argument("--customer-only", action="store_true",
+                   help="skip resources whose managed_by is not 'customer' (system/auto)")
+    e.add_argument("--emit-imports", action="store_true",
+                   help="also write imports.tf with `import {}` blocks (Terraform 1.5+) to "
+                        "ADOPT the source org's existing resources into state in place, "
+                        "instead of creating new ones on a target")
+    e.add_argument("--insecure", action="store_true",
+                   help="skip TLS verification (self-signed on-prem only; not recommended)")
+    e.set_defaults(func=export)
+
+    a = sub.add_parser("apply", help="terraform apply the module against a TARGET org")
+    a.add_argument("--dir", required=True, help="exported module directory")
+    a.add_argument("--target-base-url", help="target instance base URL")
+    a.add_argument("--target-org-id", help="target organization id")
+    a.add_argument("--token-file", help="file containing the target API token")
+    a.add_argument("--auto-approve", action="store_true", help="pass -auto-approve to terraform")
+    a.set_defaults(func=apply)
+
+    g = sub.add_parser("push", help="commit the module to a Git remote for backup")
+    g.add_argument("--dir", required=True, help="exported module directory")
+    g.add_argument("--remote", help="git remote URL (GitHub/GitLab); omit for local-only commit")
+    g.add_argument("--branch", default="main", help="branch name (default main)")
+    g.add_argument("-m", "--message", default="Monad org export", help="commit message")
+    g.add_argument("--no-push", action="store_true", help="commit but do not push")
+    g.set_defaults(func=push)
+    return p
+
+
+def main(argv):
+    args = build_parser().parse_args(argv)
+    try:
+        args.func(args)
+    except MonadAPIError as e:
+        die(str(e))
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/monad-org-export/monad-org-export.sh
+++ b/scripts/monad-org-export/monad-org-export.sh
@@ -1,0 +1,583 @@
+#!/usr/bin/env bash
+#
+# monad-org-export.sh — export a Monad organization's resources as Terraform,
+# then migrate them to another instance or commit them to Git for backup.
+#
+# This is a curl + jq port of monad-org-export.py, for environments that prefer
+# a shell tool over Python. It produces the same Terraform module and supports
+# the same workflows:
+#
+#   SaaS  -> SaaS     export from one app.monad.com org, apply to another
+#   SaaS  -> on-prem  export from app.monad.com, apply to a self-hosted instance
+#   on-prem -> SaaS   export from a self-hosted instance, apply to app.monad.com
+#   either -> Git     export, then push the module to GitHub/GitLab for backup
+#
+# "SaaS vs on-prem" is only a different --base-url; the three connection settings
+# (base URL, API token, org id) are all that change between any source/target.
+#
+# Requirements: bash 3.2+, curl, jq, and (for `apply`) terraform 1.5+, (for
+# `push`) git. The Monad API token is read from the environment, never argv.
+
+set -euo pipefail
+
+PROVIDER_SOURCE="monad-inc/monad"
+DEFAULT_BASE_URL="https://app.monad.com"
+
+usage() {
+  cat >&2 <<'EOF'
+monad-org-export.sh — export a Monad org to Terraform; migrate it or back it up.
+
+USAGE
+  monad-org-export.sh <command> [options]
+
+COMMANDS
+  export   read a SOURCE org and write a Terraform module to a directory
+  apply    run `terraform apply` against a TARGET org using that module
+  push     commit the module to a Git remote (backup / version control)
+
+export OPTIONS
+  --org-id <id>        source organization id (or $MONAD_ORGANIZATION_ID)   [required]
+  --out <dir>          output directory for the generated module            [required]
+  --base-url <url>     source instance base URL (default https://app.monad.com)
+  --token-file <path>  file holding the source API token (else $MONAD_API_TOKEN)
+  --emit-imports       also write imports.tf (Terraform 1.5+ `import {}` blocks)
+                       to ADOPT the source org's existing resources in place
+  --customer-only      skip resources whose managed_by is not 'customer'
+  --insecure           skip TLS verification (self-signed on-prem only)
+
+apply OPTIONS
+  --dir <dir>             exported module directory                         [required]
+  --target-base-url <url> target instance base URL
+  --target-org-id <id>    target organization id
+  --token-file <path>     file holding the target API token
+                          (else $MONAD_TARGET_API_TOKEN / $MONAD_API_TOKEN)
+  --auto-approve          pass -auto-approve to terraform
+
+push OPTIONS
+  --dir <dir>          exported module directory                           [required]
+  --remote <url>       git remote URL (GitHub/GitLab); omit for local-only commit
+  --branch <name>      branch name (default main)
+  -m, --message <msg>  commit message (default "Monad org export")
+  --no-push            commit but do not push
+
+AUTHENTICATION
+  The API token is read from $MONAD_API_TOKEN (export) /
+  $MONAD_TARGET_API_TOKEN (apply) or --token-file, never from the command line,
+  to keep it out of the process list. It is sent as `Authorization: ApiKey ...`.
+
+EXAMPLES
+  export MONAD_API_TOKEN=...
+  monad-org-export.sh export --org-id <SRC_ORG> --out ./org-tf
+  monad-org-export.sh export --base-url https://monad.corp.internal \
+      --org-id <SRC_ORG> --out ./org-tf --emit-imports
+  MONAD_TARGET_API_TOKEN=... monad-org-export.sh apply --dir ./org-tf \
+      --target-base-url https://app.monad.com --target-org-id <DST_ORG>
+  monad-org-export.sh push --dir ./org-tf \
+      --remote git@github.com:acme/monad-org-backup.git -m 'nightly backup'
+EOF
+}
+
+die() { echo "error: $*" >&2; exit 1; }
+need_value() { [ -n "${2:-}" ] || die "option $1 requires a value (see --help)"; }
+
+# ---------------------------------------------------------------------------
+# Shared jq definitions, prepended to every generation program.
+# ---------------------------------------------------------------------------
+read -r -d '' JQ_DEFS <<'JQ' || true
+# HCL string literal: JSON-quote (close enough to HCL), then neutralize
+# Terraform interpolation sequences so literal data is inert.
+def hclstr: @json | gsub("\\$\\{"; "$${") | gsub("%\\{"; "%%{");
+
+# Normalize a resource name into a valid, lowercase Terraform local name.
+def sanitize:
+  (. // "") | ascii_downcase | gsub("[^a-z0-9_]+"; "_")
+  | sub("^_+"; "") | sub("_+$"; "")
+  | (if . == "" then "resource" else . end)
+  | (if test("^[0-9]") then "r_" + . else . end);
+
+# Build {used,byid} from an ordered [{type,name,id}] list, assigning unique
+# local names (base, base_2, base_3, ...) globally across all resource types.
+def buildmap:
+  reduce .[] as $r ({used: {}, byid: {}};
+    ($r.name | sanitize) as $base
+    | ((.used[$base] // 0) + 1) as $n
+    | (if $n == 1 then $base else "\($base)_\($n)" end) as $local
+    | .used[$base] = $n
+    | .byid[$r.id] = {type: $r.type, local: $local, addr: "\($r.type).\($local)", name: $r.name}
+  );
+JQ
+
+# ---------------------------------------------------------------------------
+# API client
+# ---------------------------------------------------------------------------
+
+api_get() { # path -> JSON on stdout
+  local path="$1"
+  # Header is passed via --config (process substitution) so the token never
+  # appears in argv / the process list. printf is a bash builtin, not a process.
+  curl -fsS ${INSECURE:+-k} \
+    --config <(printf 'header = "Authorization: ApiKey %s"\n' "$TOKEN") \
+    "$BASE/api$path"
+}
+
+list_all() { # version segment envelope_key outfile
+  local ver="$1" seg="$2" key="$3" out="$4"
+  local offset=0 limit=100 total cnt resp
+  : > "$out.jsonl"
+  while :; do
+    resp="$(api_get "/$ver/$ORG/$seg?limit=$limit&offset=$offset")"
+    printf '%s' "$resp" | jq -c ".${key}[]?" >> "$out.jsonl"
+    total="$(printf '%s' "$resp" | jq -r '.pagination.total // 0')"
+    cnt="$(printf '%s' "$resp" | jq -r ".${key} | length // 0")"
+    offset=$((offset + limit))
+    { [ "$offset" -ge "$total" ] || [ "$cnt" -eq 0 ]; } && break
+  done
+  jq -s '.' "$out.jsonl" > "$out"
+  rm -f "$out.jsonl"
+}
+
+# ---------------------------------------------------------------------------
+# export
+# ---------------------------------------------------------------------------
+
+cmd_export() {
+  local out="" emit_imports="" customer_only=""
+  BASE="$DEFAULT_BASE_URL"; ORG="${MONAD_ORGANIZATION_ID:-}"; INSECURE=""
+  local token_file=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --org-id) need_value "$1" "${2:-}"; ORG="$2"; shift 2;;
+      --org-id=*) ORG="${1#*=}"; shift;;
+      --out) need_value "$1" "${2:-}"; out="$2"; shift 2;;
+      --out=*) out="${1#*=}"; shift;;
+      --base-url) need_value "$1" "${2:-}"; BASE="$2"; shift 2;;
+      --base-url=*) BASE="${1#*=}"; shift;;
+      --token-file) need_value "$1" "${2:-}"; token_file="$2"; shift 2;;
+      --token-file=*) token_file="${1#*=}"; shift;;
+      --emit-imports) emit_imports=1; shift;;
+      --customer-only) customer_only=1; shift;;
+      --insecure) INSECURE=1; shift;;
+      -h|--help) usage; exit 0;;
+      *) die "unknown option for export: $1 (see --help)";;
+    esac
+  done
+  [ -n "$ORG" ] || die "--org-id is required (or set MONAD_ORGANIZATION_ID)"
+  [ -n "$out" ] || die "--out is required"
+  resolve_token "$token_file" "MONAD_API_TOKEN"
+  command -v jq >/dev/null || die "jq is required"
+  command -v curl >/dev/null || die "curl is required"
+
+  mkdir -p "$out"
+  WORKDIR="$(mktemp -d)"; trap 'rm -rf "$WORKDIR"' EXIT
+
+  echo "Fetching resources from $BASE (org $ORG) ..." >&2
+  list_all v1 inputs      inputs      "$WORKDIR/inputs.json"
+  list_all v1 outputs     outputs     "$WORKDIR/outputs.json"
+  list_all v1 transforms  transforms  "$WORKDIR/transforms.json"
+  list_all v3 enrichments enrichments "$WORKDIR/enrichments.json"
+  list_all v2 secrets     secrets     "$WORKDIR/secrets.json"
+  list_all v2 pipelines   pipelines   "$WORKDIR/pipelines_list.json"
+
+  # Full pipeline objects (nodes/edges only come back on the per-id GET).
+  : > "$WORKDIR/pipelines_full.jsonl"
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    api_get "/v2/$ORG/pipelines/$pid" | jq -c '.data // .' >> "$WORKDIR/pipelines_full.jsonl"
+  done < <(jq -r '.[].id' "$WORKDIR/pipelines_list.json")
+  jq -s '.' "$WORKDIR/pipelines_full.jsonl" > "$WORKDIR/pipelines.json"
+
+  # Optionally drop non-customer-managed resources.
+  if [ -n "$customer_only" ]; then
+    local f
+    for f in inputs outputs transforms enrichments pipelines; do
+      jq '[.[] | select((.managed_by // "customer") == "customer")]' \
+        "$WORKDIR/$f.json" > "$WORKDIR/$f.filt" && mv "$WORKDIR/$f.filt" "$WORKDIR/$f.json"
+    done
+  fi
+
+  # ---- id -> Terraform address map (drives references + names everywhere)
+  jq -n --slurpfile s "$WORKDIR/secrets.json" --slurpfile i "$WORKDIR/inputs.json" \
+        --slurpfile o "$WORKDIR/outputs.json" --slurpfile t "$WORKDIR/transforms.json" \
+        --slurpfile e "$WORKDIR/enrichments.json" --slurpfile p "$WORKDIR/pipelines.json" \
+    "$JQ_DEFS"'
+      ( ($s[0] | map({type:"monad_secret",    name:.name, id:.id}))
+      + ($i[0] | map({type:"monad_input",     name:.name, id:.id}))
+      + ($o[0] | map({type:"monad_output",    name:.name, id:.id}))
+      + ($t[0] | map({type:"monad_transform", name:.name, id:.id}))
+      + ($e[0] | map({type:"monad_enrichment",name:.name, id:.id}))
+      + ($p[0] | map({type:"monad_pipeline",  name:.name, id:.id}))
+      ) | buildmap
+    ' > "$WORKDIR/map.json"
+
+  gen_component "$WORKDIR/inputs.json"      monad_input      "$WORKDIR/map.json" "$out/inputs.tf"
+  gen_component "$WORKDIR/outputs.json"     monad_output     "$WORKDIR/map.json" "$out/outputs.tf"
+  gen_component "$WORKDIR/enrichments.json" monad_enrichment "$WORKDIR/map.json" "$out/enrichments.tf"
+  gen_transforms "$WORKDIR/transforms.json" "$WORKDIR/map.json" "$out/transforms.tf"
+  gen_secrets   "$WORKDIR/map.json" "$out/secrets.tf"
+  gen_pipelines "$WORKDIR/pipelines.json" "$WORKDIR/map.json" "$out/pipelines.tf"
+  gen_scaffold  "$WORKDIR/map.json" "$out" "$emit_imports"
+
+  # Warn about pipeline nodes referencing components we did not export.
+  jq -r --slurpfile m "$WORKDIR/map.json" '
+    ($m[0]) as $MAP
+    | .[] | .name as $pn | (.nodes // [])[]
+    | select(.component_id != null and ($MAP.byid[.component_id] | not))
+    | "warning: pipeline \($pn): node \(.slug) references unexported component "
+      + "\(.component_id); emitting literal id (will not resolve elsewhere)."
+  ' "$WORKDIR/pipelines.json" >&2 || true
+
+  echo "Exported to $out/" >&2
+  local seg
+  printf '  %-11s %s\n' "secrets:"  "$(jq 'length' "$WORKDIR/secrets.json")"  >&2
+  for seg in inputs outputs transforms enrichments pipelines; do
+    printf '  %-11s %s\n' "$seg:" "$(jq 'length' "$WORKDIR/$seg.json")" >&2
+  done
+}
+
+gen_component() { # items tf_type map outfile
+  jq -r --arg TYPE "$2" --slurpfile m "$3" "$JQ_DEFS"'
+    ($m[0]) as $MAP
+    | .[] | ($MAP.byid[.id]) as $meta
+    | "resource \"\($TYPE)\" \"\($meta.local)\" {\n"
+      + "  name        = \(.name | hclstr)\n"
+      + (if (.description // "") != "" then "  description = \(.description | hclstr)\n" else "" end)
+      + "  type        = \((.type // "") | hclstr)\n"
+      + ( (.config.settings // {}) as $s | (.config.secrets // {}) as $sec
+          | if (($s | length) > 0) or (($sec | length) > 0) then
+              "  config {\n"
+              + (if ($s   | length) > 0 then "    settings = jsondecode(\(($s   | tojson) | hclstr))\n" else "" end)
+              + (if ($sec | length) > 0 then "    secrets  = jsondecode(\(($sec | tojson) | hclstr))\n" else "" end)
+              + "  }\n"
+            else "" end )
+      + "}\n"
+  ' "$1" > "$4"
+  [ -s "$4" ] || rm -f "$4"
+}
+
+gen_transforms() { # items map outfile
+  jq -r --slurpfile m "$2" "$JQ_DEFS"'
+    ($m[0]) as $MAP
+    | .[] | ($MAP.byid[.id]) as $meta
+    | "resource \"monad_transform\" \"\($meta.local)\" {\n"
+      + "  name        = \(.name | hclstr)\n"
+      + (if (.description // "") != "" then "  description = \(.description | hclstr)\n" else "" end)
+      + "  config = jsondecode(\(((.config // {}) | tojson) | hclstr))\n"
+      + "}\n"
+  ' "$1" > "$3"
+  [ -s "$3" ] || rm -f "$3"
+}
+
+gen_secrets() { # map outfile
+  jq -r "$JQ_DEFS"'
+    .byid | to_entries
+    | map(select(.value.type == "monad_secret"))
+    | .[] | .value
+    | "resource \"monad_secret\" \"\(.local)\" {\n"
+      + "  name  = \(.name | hclstr)\n"
+      + "  value = var.secret_\(.local)\n"
+      + "}\n"
+  ' "$1" > "$2"
+  [ -s "$2" ] || rm -f "$2"
+}
+
+gen_pipelines() { # items map outfile
+  jq -r --slurpfile m "$2" "$JQ_DEFS"'
+    ($m[0]) as $MAP
+    | .[] | ($MAP.byid[.id]) as $meta
+    | (reduce (.nodes[]?) as $n ({}; .[$n.id] = $n.slug)) as $slug
+    | "resource \"monad_pipeline\" \"\($meta.local)\" {\n"
+      + "  name        = \(.name | hclstr)\n"
+      + (if (.description // "") != "" then "  description = \(.description | hclstr)\n" else "" end)
+      + "  enabled     = \(.enabled // true)\n"
+      + ( [ .nodes[]? | ($MAP.byid[.component_id]) as $cm
+          | "  nodes {\n"
+            + "    slug           = \(.slug | hclstr)\n"
+            + "    component_type = \((.component_type // "") | hclstr)\n"
+            + "    component_id   = " + (if $cm then "\($cm.addr).id" else (.component_id | hclstr) end) + "\n"
+            + "  }\n"
+        ] | join("") )
+      + ( [ .edges[]? | (.conditions // {}) as $c
+          | "  edges {\n"
+            + (if (.name // "") != ""        then "    name                    = \(.name | hclstr)\n" else "" end)
+            + (if (.description // "") != "" then "    description             = \(.description | hclstr)\n" else "" end)
+            + "    from_node_instance_slug = \(($slug[.from_node_instance_id] // "") | hclstr)\n"
+            + "    to_node_instance_slug   = \(($slug[.to_node_instance_id] // "") | hclstr)\n"
+            + "    condition {\n"
+            + "      operator = \(($c.operator // "always") | hclstr)\n"
+            + ( [ ($c.conditions // [])[] | (.config // {}) as $cfg
+                | "      conditions {\n"
+                  + (if (.type_id // "") != "" then "        type_id = \(.type_id | hclstr)\n" else "" end)
+                  + ( [ (if ($cfg.key // "") != "" then "          key   = \($cfg.key | hclstr)" else empty end),
+                        (if ($cfg.value != null and $cfg.value != "" and $cfg.value != [])
+                          then "          value = [" + (($cfg.value | if type == "array" then . else [.] end)
+                                 | map(tostring | hclstr) | join(", ")) + "]"
+                          else empty end),
+                        (if ($cfg.rate // "") != "" then "          rate  = \($cfg.rate | hclstr)" else empty end)
+                      ] as $cl
+                      | if ($cl | length) > 0 then "        config {\n" + ($cl | join("\n")) + "\n        }\n" else "" end )
+                  + "      }\n"
+              ] | join("") )
+            + "    }\n"
+            + "  }\n"
+        ] | join("") )
+      + "}\n"
+  ' "$1" > "$3"
+  [ -s "$3" ] || rm -f "$3"
+}
+
+gen_scaffold() { # map outdir emit_imports
+  local map="$1" outdir="$2" emit="$3"
+
+  cat > "$outdir/versions.tf" <<EOF
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    monad = {
+      source = "$PROVIDER_SOURCE"
+    }
+  }
+}
+EOF
+
+  cat > "$outdir/provider.tf" <<'EOF'
+provider "monad" {
+  base_url        = var.monad_base_url
+  api_token       = var.monad_api_token
+  organization_id = var.monad_organization_id
+}
+EOF
+
+  {
+    cat <<EOF
+variable "monad_base_url" {
+  type    = string
+  default = "$DEFAULT_BASE_URL"
+}
+
+variable "monad_api_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "monad_organization_id" {
+  type = string
+}
+EOF
+    jq -r '
+      .byid | to_entries | map(select(.value.type == "monad_secret")) | .[] | .value
+      | "\nvariable \"secret_\(.local)\" {\n  description = \"Value for secret: \(.name)\"\n  type        = string\n  sensitive   = true\n}"
+    ' "$map"
+  } > "$outdir/variables.tf"
+
+  {
+    cat <<EOF
+# Target connection — fill in the instance you are applying TO.
+monad_base_url        = "$DEFAULT_BASE_URL"   # self-hosted: https://monad.your-domain
+monad_api_token       = "REPLACE_ME"
+monad_organization_id = "REPLACE_ME"
+EOF
+    if [ "$(jq '[.byid[] | select(.type=="monad_secret")] | length' "$map")" -gt 0 ]; then
+      echo
+      echo "# Secret values are NOT exported (Monad never returns them). Supply each:"
+      jq -r '.byid | to_entries | map(select(.value.type=="monad_secret")) | .[] | .value
+        | "secret_\(.local) = \"REPLACE_ME\"  # \(.name)"' "$map"
+    fi
+  } > "$outdir/terraform.tfvars.example"
+
+  jq --arg org "$ORG" --arg base "$BASE" '
+    {organization_id: $org, source_base_url: $base,
+     resources: (.byid | map_values({address: .addr, name: .name, type: .type}))}
+  ' "$map" > "$outdir/MANIFEST.json"
+
+  if [ -n "$emit" ]; then
+    {
+      cat <<'EOF'
+# Generated by monad-org-export.sh --emit-imports.
+# Adopts the source org's existing resources into Terraform state.
+# Requires Terraform >= 1.5. Delete this file after the first apply.
+# NOTE: secret VALUES are still not readable, so an imported
+# monad_secret may show a value diff until you supply it via tfvars.
+
+EOF
+      jq -r '.byid | to_entries[]
+        | "import {\n  to = \(.value.addr)\n  id = \"\(.key)\"\n}"' "$map"
+    } > "$outdir/imports.tf"
+  fi
+
+  write_readme "$outdir"
+  write_notes "$map" "$outdir"
+}
+
+write_notes() { # map outdir
+  {
+    echo "# Export notes"
+    echo
+    echo "Source org: \`$ORG\`"
+    echo "Source URL: \`$BASE\`"
+    echo
+    echo "## Resource counts"
+    echo
+    jq -r '[.byid[]] | group_by(.type) | .[] | "- \(.[0].type): \(length)"' "$1"
+    echo
+    echo "## Secrets"
+    echo
+    echo "Secret **values are never returned by the Monad API**, so this export"
+    echo "contains secret *definitions* only. Before \`apply\`, set each"
+    echo "\`secret_*\` variable in \`terraform.tfvars\` (or via \`TF_VAR_secret_*\`)."
+    echo
+    echo "Secret *references* embedded in a connector's \`config.secrets\` are"
+    echo "emitted verbatim by this shell version; if you migrate to a different"
+    echo "instance, remap them to \`monad_secret.<name>.reference\` by hand."
+  } > "$2/EXPORT_NOTES.md"
+}
+
+write_readme() { # outdir
+  cat > "$1/README.md" <<'EOF'
+# Monad organization export (Terraform)
+
+Generated by `monad-org-export.sh`. A portable snapshot of a Monad organization:
+inputs, outputs, transforms, enrichments, secrets (definitions only), pipelines.
+
+## Apply to a target instance
+
+```sh
+cp terraform.tfvars.example terraform.tfvars   # then edit it
+terraform init
+terraform plan
+terraform apply
+```
+
+Connection settings (`monad_base_url`, `monad_api_token`,
+`monad_organization_id`) select the target. `https://app.monad.com` is the SaaS
+default; point `monad_base_url` at your own hostname for a self-hosted instance.
+
+## Secrets
+
+Secret values are not exported (the API never returns them). Set each
+`secret_*` variable before applying — see `EXPORT_NOTES.md`.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+cmd_apply() {
+  local dir="" tbase="" torg="" auto="" token_file=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dir) need_value "$1" "${2:-}"; dir="$2"; shift 2;;
+      --dir=*) dir="${1#*=}"; shift;;
+      --target-base-url) need_value "$1" "${2:-}"; tbase="$2"; shift 2;;
+      --target-base-url=*) tbase="${1#*=}"; shift;;
+      --target-org-id) need_value "$1" "${2:-}"; torg="$2"; shift 2;;
+      --target-org-id=*) torg="${1#*=}"; shift;;
+      --token-file) need_value "$1" "${2:-}"; token_file="$2"; shift 2;;
+      --token-file=*) token_file="${1#*=}"; shift;;
+      --auto-approve) auto="-auto-approve"; shift;;
+      -h|--help) usage; exit 0;;
+      *) die "unknown option for apply: $1 (see --help)";;
+    esac
+  done
+  [ -n "$dir" ] || die "--dir is required"
+  [ -f "$dir/versions.tf" ] || die "$dir does not look like an exported module (no versions.tf)"
+  command -v terraform >/dev/null || die "terraform 1.5+ is required for apply"
+
+  [ -n "$tbase" ] && export TF_VAR_monad_base_url="$tbase"
+  [ -n "$torg" ] && export TF_VAR_monad_organization_id="$torg"
+  if [ -n "$token_file" ]; then
+    TF_VAR_monad_api_token="$(cat "$token_file")"; export TF_VAR_monad_api_token
+  elif [ -n "${MONAD_TARGET_API_TOKEN:-}" ]; then
+    export TF_VAR_monad_api_token="$MONAD_TARGET_API_TOKEN"
+  elif [ -n "${MONAD_API_TOKEN:-}" ]; then
+    export TF_VAR_monad_api_token="$MONAD_API_TOKEN"
+  fi
+
+  ( cd "$dir" && terraform init -input=false && terraform apply -input=false $auto )
+}
+
+# ---------------------------------------------------------------------------
+# push (Git backup / version control)
+# ---------------------------------------------------------------------------
+
+cmd_push() {
+  local dir="" remote="" branch="main" message="Monad org export" no_push=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --dir) need_value "$1" "${2:-}"; dir="$2"; shift 2;;
+      --dir=*) dir="${1#*=}"; shift;;
+      --remote) need_value "$1" "${2:-}"; remote="$2"; shift 2;;
+      --remote=*) remote="${1#*=}"; shift;;
+      --branch) need_value "$1" "${2:-}"; branch="$2"; shift 2;;
+      --branch=*) branch="${1#*=}"; shift;;
+      -m|--message) need_value "$1" "${2:-}"; message="$2"; shift 2;;
+      --message=*) message="${1#*=}"; shift;;
+      --no-push) no_push=1; shift;;
+      -h|--help) usage; exit 0;;
+      *) die "unknown option for push: $1 (see --help)";;
+    esac
+  done
+  [ -n "$dir" ] || die "--dir is required"
+  [ -d "$dir" ] || die "$dir does not exist"
+  command -v git >/dev/null || die "git is required for push"
+
+  cat > "$dir/.gitignore" <<'EOF'
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+*.auto.tfvars
+EOF
+
+  if [ ! -d "$dir/.git" ]; then
+    git -C "$dir" init -b "$branch" >/dev/null 2>&1 || git -C "$dir" init >/dev/null
+  fi
+  git -C "$dir" checkout -B "$branch" >/dev/null 2>&1 || true
+  if [ -n "$remote" ]; then
+    if git -C "$dir" remote | grep -qx origin; then
+      git -C "$dir" remote set-url origin "$remote"
+    else
+      git -C "$dir" remote add origin "$remote"
+    fi
+  fi
+  git -C "$dir" add -A
+  if git -C "$dir" diff --cached --quiet; then
+    echo "Nothing to commit (working tree matches last backup)." >&2
+  else
+    git -C "$dir" commit -m "$message" >/dev/null
+  fi
+  if [ -n "$remote" ] && [ -z "$no_push" ]; then
+    git -C "$dir" push -u origin "$branch"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+resolve_token() { # token_file env_name  -> sets global TOKEN
+  local tf="$1" env_name="$2"
+  if [ -n "$tf" ]; then
+    [ -f "$tf" ] || die "token file not found: $tf"
+    TOKEN="$(cat "$tf")"
+  else
+    eval "TOKEN=\"\${$env_name:-\${MONAD_API_TOKEN:-}}\""
+  fi
+  [ -n "${TOKEN:-}" ] || die "API token required: set \$$env_name or pass --token-file. \
+(Tokens are read from env/file, never argv, to keep them out of 'ps'.)"
+}
+
+main() {
+  [ $# -ge 1 ] || { usage; exit 1; }
+  local cmd="$1"; shift
+  case "$cmd" in
+    export) cmd_export "$@";;
+    apply)  cmd_apply "$@";;
+    push)   cmd_push "$@";;
+    -h|--help) usage; exit 0;;
+    *) echo "error: unknown command '$cmd' (expected export, apply, or push)" >&2; usage; exit 1;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## What

Adds `scripts/monad-org-export/` — a Python (standard-library only) tool that exports an entire Monad **organization** to a Terraform module, then serves three workflows from that single artifact:

- **Migrate** between instances — SaaS ↔ self-hosted is only a different `--base-url`; the three connection settings (base URL, API token, org id) are all that change.
- **Back up** to a GitHub/GitLab remote for version control.
- **Adopt in place** via `--emit-imports`, which writes Terraform 1.5+ `import {}` blocks to bring an existing org under management without recreating resources.

## Why

The Monad Terraform provider can manage every resource type but has **no data sources**, so it can't enumerate an org on its own. This tool reads inputs, outputs, transforms, enrichments, secrets, and pipelines over the REST API and emits faithful HCL — rewriting pipeline component references (and, best-effort, secret references) so the module is portable across instances.

## Verification

Tested against a live sandbox org (46 resources):

- `export` → `terraform fmt` / `init` / `validate` pass against the real registry provider.
- `terraform plan` (create): **46 to add, 0 to change, 0 to destroy** — all cross-references resolve.
- `--emit-imports` + `terraform plan`: **46 to import, 0 to add** — clean adopt-in-place.
- `push` git flow works; `.gitignore` excludes state and `terraform.tfvars`.

## Caveats (also in the README)

- **Secret values are never exported** (the API doesn't return them) — emitted as sensitive Terraform variables to supply at apply time.
- `--emit-imports` is for the *same* org (ids must match the target), not cross-instance migration.
- Captures provider-supported resource types only; does not copy ingested data, users/roles, API keys, or billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)